### PR TITLE
Fixed navigation redirection for Reminders

### DIFF
--- a/app/src/main/res/menu/activity_main_drawer.xml
+++ b/app/src/main/res/menu/activity_main_drawer.xml
@@ -36,10 +36,10 @@
             android:icon="@drawable/bot_menu_exit"
             android:title="@string/exit" />
 
-        <item
+        <!--<item
             android:id="@+id/nav_reminders"
             android:icon="@drawable/ic_reminder"
             android:title="@string/menu_reminders"
-            app:destination="@id/nav_reminders" />
+            app:destination="@id/nav_reminders" />-->
     </group>
 </menu>

--- a/app/src/main/res/navigation/mobile_navigation.xml
+++ b/app/src/main/res/navigation/mobile_navigation.xml
@@ -33,19 +33,19 @@
         tools:layout="@layout/fragment_emergency" />
     <fragment
         android:id="@+id/nav_notification"
-        android:name="com.example.b07_project21.ui.notification.NotificationFragment"
-        android:label="@string/notifications"
-        tools:layout="@layout/fragment_notification" />
+        android:name="com.example.b07_project21.ui.reminder.ReminderListFragment"
+        android:label="@string/menu_reminders"
+        tools:layout="@layout/fragment_reminder_list" />
     <fragment
         android:id="@+id/nav_exit"
         android:name="com.example.b07_project21.ui.exit.ExitFragment"
         android:label="@string/exit"
         tools:layout="@layout/fragment_exit" />
-    <fragment
+    <!--<fragment
         android:id="@+id/nav_reminders"
         android:name="com.example.b07_project21.ReminderListFragment"
         android:label="@string/menu_reminders"
-        tools:layout="@layout/fragment_reminder_list" />
+        tools:layout="@layout/fragment_reminder_list" />-->
     <!-- Questionnaire -->
     <!--<fragment
         android:id="@+id/nav_questionnaire"


### PR DESCRIPTION
# Pull Request

## Description

Resolved the issue with navigation redirection to Reminders; the placement of the file was moved, so navigation would break when going into the Reminders page.

Fixes # (reminders)

## Type of Change

- [x] Bug fix

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes